### PR TITLE
Add navbar and home page

### DIFF
--- a/fullstack-docker/frontend/src/App.js
+++ b/fullstack-docker/frontend/src/App.js
@@ -1,8 +1,12 @@
 import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
 import { Routes, Route } from "react-router-dom";
+import { Chatbot } from 'chatbot-widget';
+import Navbar from "./components/Navbar";
+import Home from "./components/Home";
 import PrestitoForm from "./components/PrestitoForm";
-import LibriInGiro from "./LibriInGiro"; // Usa il path corretto se sta in una cartella
+import LibriInGiro from "./LibriInGiro";
+import 'chatbot-widget/dist/Chatbot.css';
 function App() {
-    return (_jsx("div", { style: { padding: "2rem" }, children: _jsxs(Routes, { children: [_jsx(Route, { path: "/", element: _jsx(PrestitoForm, {}) }), _jsx(Route, { path: "/libri-in-giro", element: _jsx(LibriInGiro, {}) })] }) }));
+    return (_jsxs("div", { style: { padding: "2rem" }, children: [_jsx(Navbar, {}), _jsxs(Routes, { children: [_jsx(Route, { path: "/", element: _jsx(Home, {}) }), _jsx(Route, { path: "/libri-in-giro", element: _jsx(LibriInGiro, {}) }), _jsx(Route, { path: "/registra-prestito", element: _jsx(PrestitoForm, {}) })] }), _jsx(Chatbot, { apiUrl: "http://localhost:5005", avatarUrl: "/chatbot-avatar.png" })] }));
 }
 export default App;

--- a/fullstack-docker/frontend/src/App.tsx
+++ b/fullstack-docker/frontend/src/App.tsx
@@ -1,17 +1,20 @@
 import { Routes, Route } from "react-router-dom";
 import { Chatbot } from 'chatbot-widget';
+import Navbar from "./components/Navbar";
+import Home from "./components/Home";
 import PrestitoForm from "./components/PrestitoForm";
-import LibriInGiro from "./LibriInGiro"; // Usa il path corretto se sta in una cartella
+import LibriInGiro from "./LibriInGiro";
 import 'chatbot-widget/dist/Chatbot.css';
 
 function App() {
   return (
     <div style={{ padding: "2rem" }}>
+      <Navbar />
       <Routes>
-        <Route path="/" element={<PrestitoForm />} />
+        <Route path="/" element={<Home />} />
         <Route path="/libri-in-giro" element={<LibriInGiro />} />
+        <Route path="/registra-prestito" element={<PrestitoForm />} />
       </Routes>
-
       {/* Chatbot persistente in tutte le pagine */}
       <Chatbot apiUrl="http://localhost:5005" avatarUrl="/chatbot-avatar.png" />
     </div>

--- a/fullstack-docker/frontend/src/components/Home.css
+++ b/fullstack-docker/frontend/src/components/Home.css
@@ -1,0 +1,4 @@
+.home {
+  text-align: center;
+  margin-top: 2rem;
+}

--- a/fullstack-docker/frontend/src/components/Home.js
+++ b/fullstack-docker/frontend/src/components/Home.js
@@ -1,0 +1,4 @@
+import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
+import './Home.css';
+const Home = () => (_jsxs("div", { className: "home", children: [_jsx("h1", { children: "Benvenuto nella Biblioteca" }), _jsx("p", { children: "Usa la barra di navigazione per esplorare l'app." })] }));
+export default Home;

--- a/fullstack-docker/frontend/src/components/Home.tsx
+++ b/fullstack-docker/frontend/src/components/Home.tsx
@@ -1,0 +1,10 @@
+import './Home.css';
+
+const Home: React.FC = () => (
+  <div className="home">
+    <h1>Benvenuto nella Biblioteca</h1>
+    <p>Usa la barra di navigazione per esplorare l'app.</p>
+  </div>
+);
+
+export default Home;

--- a/fullstack-docker/frontend/src/components/Navbar.css
+++ b/fullstack-docker/frontend/src/components/Navbar.css
@@ -1,0 +1,21 @@
+.navbar {
+  background-color: #333;
+  padding: 1rem;
+}
+
+.navbar ul {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+}
+
+.navbar a {
+  color: #fff;
+  text-decoration: none;
+}
+
+.navbar a:hover {
+  text-decoration: underline;
+}

--- a/fullstack-docker/frontend/src/components/Navbar.js
+++ b/fullstack-docker/frontend/src/components/Navbar.js
@@ -1,0 +1,5 @@
+import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
+import { Link } from 'react-router-dom';
+import './Navbar.css';
+const Navbar = () => (_jsx("nav", { className: "navbar", children: _jsxs("ul", { children: [_jsx("li", { children: _jsx(Link, { to: "/", children: "Home" }) }), _jsx("li", { children: _jsx(Link, { to: "/libri-in-giro", children: "Libri in giro" }) }), _jsx("li", { children: _jsx(Link, { to: "/registra-prestito", children: "Registra un prestito" }) })] }) }));
+export default Navbar;

--- a/fullstack-docker/frontend/src/components/Navbar.tsx
+++ b/fullstack-docker/frontend/src/components/Navbar.tsx
@@ -1,0 +1,14 @@
+import { Link } from 'react-router-dom';
+import './Navbar.css';
+
+const Navbar: React.FC = () => (
+  <nav className="navbar">
+    <ul>
+      <li><Link to="/">Home</Link></li>
+      <li><Link to="/libri-in-giro">Libri in giro</Link></li>
+      <li><Link to="/registra-prestito">Registra un prestito</Link></li>
+    </ul>
+  </nav>
+);
+
+export default Navbar;


### PR DESCRIPTION
## Summary
- create new `Home` and `Navbar` components with simple CSS
- show navigation bar on every page
- add a home view and move `PrestitoForm` to `/registra-prestito`

## Testing
- `npm install`
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840386543c883238a3cad82e2a57e3f